### PR TITLE
Added new dry run vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - TBD
+### Changed
+- Separated `dry_run_enabled` variable into `path_cleanup_dry_run_enabled` and `metadata_cleanup_dry_run_enabled` so one module can be used in dry run mode without affecting the other.  
+
 ## [3.0.0] - 2020-09-11
 ### Added
 - Kubernetes deployment options for new Metadata Cleanup module. 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ If the chosen `db_password_strategy` is `aws-secrets-manager`, this terraform mo
 | db\_password\_strategy | Strategy to acquire the password for the RDS instance. Supported strategies: aws-secrets-manager. | `string` | `"aws-secrets-manager"` | no |
 | db\_username | Username for the master DB user. | `string` | `"beekeeper"` | no |
 | docker\_registry\_auth\_secret\_name | Docker Registry authentication SecretManager secret name. | `string` | `""` | no |
-| dry\_run\_enabled | Enable to perform dry runs of deletions only. | `string` | `"false"` | no |
+| path\_cleanup\_dry\_run\_enabled | Enable Path Cleanup to perform dry runs of deletions only. | `string` | `"false"` | no |
+| metadata\_cleanup\_dry\_run\_enabled | Enable Metadata Cleanup to perform dry runs of deletions only. | `string` | `"false"` | no |
 | graphite\_enabled | Enable to produce Graphite metrics - true or false. | `string` | `"false"` | no |
 | graphite\_host | Graphite metrics host. | `string` | `"localhost"` | no |
 | graphite\_port | Graphite port. | `string` | `"2003"` | no |

--- a/config-templates.tf
+++ b/config-templates.tf
@@ -33,7 +33,7 @@ data "template_file" "beekeeper_path_cleanup_config" {
     db_endpoint        = aws_db_instance.beekeeper.endpoint
     db_username        = aws_db_instance.beekeeper.username
     scheduler_delay_ms = var.scheduler_delay_ms
-    dry_run_enabled    = var.dry_run_enabled
+    dry_run_enabled    = var.path_cleanup_dry_run_enabled
     graphite_config    = var.graphite_enabled == "false" ? "" : data.template_file.beekeeper_graphite_config.rendered
   }
 }
@@ -45,7 +45,7 @@ data "template_file" "beekeeper_metadata_cleanup_config" {
     db_endpoint        = aws_db_instance.beekeeper.endpoint
     db_username        = aws_db_instance.beekeeper.username
     scheduler_delay_ms = var.scheduler_delay_ms
-    dry_run_enabled    = var.dry_run_enabled
+    dry_run_enabled    = var.metadata_cleanup_dry_run_enabled
     metastore_uri      = var.metastore_uri
     graphite_config    = var.graphite_enabled == "false" ? "" : data.template_file.beekeeper_graphite_config.rendered
   }

--- a/variables.tf
+++ b/variables.tf
@@ -246,8 +246,14 @@ variable "scheduler_delay_ms" {
   default     = "300000"
 }
 
-variable "dry_run_enabled" {
-  description = "Enable to perform dry runs of deletions only."
+variable "path_cleanup_dry_run_enabled" {
+  description = "Enable Path Cleanup to perform dry runs of deletions only."
+  default     = "false"
+  type        = string
+}
+
+variable "metadata_cleanup_dry_run_enabled" {
+  description = "Enable Metadata Cleanup to perform dry runs of deletions only."
   default     = "false"
   type        = string
 }


### PR DESCRIPTION
Separated `dry_run_enabled` variable into `path_cleanup_dry_run_enabled` and `metadata_cleanup_dry_run_enabled` so one module can be used in dry run mode without affecting the other. 