### PR TITLE
Added docker registry name to apiary-lifecycle module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.0.2] - 2021-01-27
+## [3.0.2] - 2021-02-01
 ### Added
 - Added variable `docker_registry_secret_name` to pull docker images from a private registry.
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [3.0.2] - 2021-02-01
 ### Added
 - Added variable `docker_registry_secret_name` to pull docker images from a private registry.
-### Fixed
-- Updated terraform scripts to new Kubernetes provider syntax.
 
 ## [3.0.1] - 2020-09-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2021-01-27
+### Added
+- Added variable `docker_registry_secret_name` to pull docker images from a private registry.
+### Fixed
+- Updated terraform scripts to new Kubernetes provider syntax.
+
 ## [3.0.1] - 2020-09-18
 ### Changed
 - Separated `dry_run_enabled` variable into `path_cleanup_dry_run_enabled` and `metadata_cleanup_dry_run_enabled` so one module can be used in dry run mode without affecting the other.  

--- a/k8s-metadata-cleanup.tf
+++ b/k8s-metadata-cleanup.tf
@@ -64,11 +64,11 @@ resource "kubernetes_deployment" "beekeeper_metadata_cleanup" {
           }
 
           resources {
-            limits {
+            limits = {
               memory = var.k8s_metadata_cleanup_memory
               cpu    = var.k8s_metadata_cleanup_cpu
             }
-            requests {
+            requests = {
               memory = var.k8s_metadata_cleanup_memory
               cpu    = var.k8s_metadata_cleanup_cpu
             }

--- a/k8s-metadata-cleanup.tf
+++ b/k8s-metadata-cleanup.tf
@@ -99,6 +99,9 @@ resource "kubernetes_deployment" "beekeeper_metadata_cleanup" {
             value = base64encode(data.template_file.beekeeper_metadata_cleanup_config.rendered)
           }
         }
+        image_pull_secrets {
+          name = var.docker_registry_secret_name
+        }
       }
     }
   }

--- a/k8s-path-cleanup.tf
+++ b/k8s-path-cleanup.tf
@@ -100,6 +100,9 @@ resource "kubernetes_deployment" "beekeeper_path_cleanup" {
             value = base64encode(data.template_file.beekeeper_path_cleanup_config.rendered)
           }
         }
+        image_pull_secrets {
+          name = var.docker_registry_secret_name
+        }
       }
     }
   }

--- a/k8s-path-cleanup.tf
+++ b/k8s-path-cleanup.tf
@@ -65,11 +65,11 @@ resource "kubernetes_deployment" "beekeeper_path_cleanup" {
           }
 
           resources {
-            limits {
+            limits = {
               memory = var.k8s_path_cleanup_memory
               cpu    = var.k8s_path_cleanup_cpu
             }
-            requests {
+            requests = {
               memory = var.k8s_path_cleanup_memory
               cpu    = var.k8s_path_cleanup_cpu
             }

--- a/k8s-scheduler-apiary.tf
+++ b/k8s-scheduler-apiary.tf
@@ -64,11 +64,11 @@ resource "kubernetes_deployment" "beekeeper_scheduler_apiary" {
           }
 
           resources {
-            limits {
+            limits = {
               memory = var.k8s_scheduler_apiary_memory
               cpu    = var.k8s_scheduler_apiary_cpu
             }
-            requests {
+            requests = {
               memory = var.k8s_scheduler_apiary_memory
               cpu    = var.k8s_scheduler_apiary_cpu
             }

--- a/k8s-scheduler-apiary.tf
+++ b/k8s-scheduler-apiary.tf
@@ -100,7 +100,7 @@ resource "kubernetes_deployment" "beekeeper_scheduler_apiary" {
           }
         }
         image_pull_secrets {
-          name = var.docker_registry_auth_secret_name
+          name = var.docker_registry_secret_name
         }
       }
     }

--- a/k8s-scheduler-apiary.tf
+++ b/k8s-scheduler-apiary.tf
@@ -99,6 +99,9 @@ resource "kubernetes_deployment" "beekeeper_scheduler_apiary" {
             value = base64encode(data.template_file.beekeeper_scheduler_apiary_config.rendered)
           }
         }
+        image_pull_secrets {
+          name = var.docker_registry_auth_secret_name
+        }
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -225,6 +225,11 @@ variable "metadata_cleanup_docker_image_version" {
   default     = "latest"
 }
 
+variable "docker_registry_secret_name" {
+  description = "Docker Registry secret name."
+  type        = string
+  default     = ""
+}
 
 variable "docker_registry_auth_secret_name" {
   description = "Docker Registry authentication SecretManager secret name."

--- a/variables.tf
+++ b/variables.tf
@@ -229,7 +229,7 @@ variable "metadata_cleanup_docker_image_version" {
 variable "docker_registry_auth_secret_name" {
   description = "Docker Registry authentication SecretManager secret name."
   type        = string
-  default     = "hub-docker-remote.artylab.expedia.biz"
+  default     = ""
 }
 
 # Application specific

--- a/variables.tf
+++ b/variables.tf
@@ -229,7 +229,7 @@ variable "metadata_cleanup_docker_image_version" {
 variable "docker_registry_auth_secret_name" {
   description = "Docker Registry authentication SecretManager secret name."
   type        = string
-  default     = ""
+  default     = "hub-docker-remote.artylab.expedia.biz"
 }
 
 # Application specific


### PR DESCRIPTION
Added a secret docker registry name to avoid the issue with Docker Hub Rate Limiting (More info in EGDL-1556).

**Question**: I have seen that in _variables.tf_ exists the following key "_docker_registry_auth_secret_name_". It was with an empty default value, I thought that it's better to use this one instead of creating a new one called: "_docker_registry_secret_".

But, this key/value is being called by other scripts like ecs-templates.tf, ecs-iam.tf, common.tf... So, I am not sure if I did right.