### PR TITLE
Pin k8s provider version and fix Flyway table provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - Renamed `Cleanup` to `Path Cleanup`, and `Path Scheduler` to `Scheduler Apiary` to match name changes in Beekeeper.
 
+## [2.1.4] - 2021-04-06
+### Changed
+- Pin K8S provider version to `1.x` for compatibility with other Apiary components deployed in the same Terraform state file.
+- Don't use instance alias as part of default DB name since all the Flyway scripts expect "beekeeper" as the db name.
+
 ## [2.1.3] - 2020-08-07
 ### Changed
 - Fix multi instance deployment resource names.

--- a/common.tf
+++ b/common.tf
@@ -6,8 +6,8 @@
 
 locals {
   instance_alias = var.instance_name == "" ? "beekeeper" : format("beekeeper-%s", var.instance_name)
-  queue_alias = var.instance_name == "" ? var.queue_name : "${var.queue_name}-${var.instance_name}"
-  k8s_app_alias = var.k8s_app_name == "" ? "beekeeper" : format("beekeeper-%s", var.k8s_app_name)
+  queue_alias    = var.instance_name == "" ? var.queue_name : "${var.queue_name}-${var.instance_name}"
+  k8s_app_alias  = var.k8s_app_name == "" ? "beekeeper" : format("beekeeper-%s", var.k8s_app_name)
 
   aws_region_key              = "AWS_REGION"
   aws_default_region_key      = "AWS_DEFAULT_REGION"

--- a/config-templates.tf
+++ b/config-templates.tf
@@ -19,11 +19,11 @@ data "template_file" "beekeeper_scheduler_apiary_config" {
   template = file("${path.module}/files/beekeeper-scheduler-apiary-config.json")
 
   vars = {
-    db_endpoint      = aws_db_instance.beekeeper.endpoint
-    db_name          = aws_db_instance.beekeeper.name
-    db_username      = aws_db_instance.beekeeper.username
-    queue            = aws_sqs_queue.beekeeper.id
-    graphite_config  = var.graphite_enabled == "false" ? "" : data.template_file.beekeeper_graphite_config.rendered
+    db_endpoint     = aws_db_instance.beekeeper.endpoint
+    db_name         = aws_db_instance.beekeeper.name
+    db_username     = aws_db_instance.beekeeper.username
+    queue           = aws_sqs_queue.beekeeper.id
+    graphite_config = var.graphite_enabled == "false" ? "" : data.template_file.beekeeper_graphite_config.rendered
   }
 }
 

--- a/k8s-metadata-cleanup-iam.tf
+++ b/k8s-metadata-cleanup-iam.tf
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
- 
+
 resource "aws_iam_role" "beekeeper_k8s_role_metadata_cleanup_iam" {
   count = var.instance_type == "k8s" ? 1 : 0
   name  = "${local.instance_alias}-metadata-cleanup-${var.aws_region}"

--- a/k8s-metadata-cleanup.tf
+++ b/k8s-metadata-cleanup.tf
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
- 
+
 locals {
   metadata_cleanup_name      = "metadata-cleanup"
   metadata_cleanup_full_name = "${local.k8s_app_alias}-metadata-cleanup"
@@ -39,9 +39,9 @@ resource "kubernetes_deployment" "beekeeper_metadata_cleanup" {
         labels = local.metadata_cleanup_label_name_instance
         annotations = {
           "iam.amazonaws.com/role" = aws_iam_role.beekeeper_k8s_role_metadata_cleanup_iam[count.index].arn
-          "prometheus.io/scrape": var.prometheus_enabled
-          "prometheus.io/port": var.k8s_metadata_cleanup_port
-          "prometheus.io/path": "/actuator/prometheus"
+          "prometheus.io/scrape" : var.prometheus_enabled
+          "prometheus.io/port" : var.k8s_metadata_cleanup_port
+          "prometheus.io/path" : "/actuator/prometheus"
         }
       }
 
@@ -64,11 +64,11 @@ resource "kubernetes_deployment" "beekeeper_metadata_cleanup" {
           }
 
           resources {
-            limits = {
+            limits {
               memory = var.k8s_metadata_cleanup_memory
               cpu    = var.k8s_metadata_cleanup_cpu
             }
-            requests = {
+            requests {
               memory = var.k8s_metadata_cleanup_memory
               cpu    = var.k8s_metadata_cleanup_cpu
             }
@@ -85,11 +85,11 @@ resource "kubernetes_deployment" "beekeeper_metadata_cleanup" {
           }
 
           env {
-            name  = local.db_password_key
+            name = local.db_password_key
             value_from {
               secret_key_ref {
-                name  = var.k8s_db_password_secret
-                key   = local.db_password_key
+                name = var.k8s_db_password_secret
+                key  = local.db_password_key
               }
             }
           }

--- a/k8s-path-cleanup-iam.tf
+++ b/k8s-path-cleanup-iam.tf
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
- 
+
 resource "aws_iam_role" "beekeeper_k8s_role_path_cleanup_iam" {
   count = var.instance_type == "k8s" ? 1 : 0
   name  = "${local.instance_alias}-path-cleanup-${var.aws_region}"

--- a/k8s-path-cleanup.tf
+++ b/k8s-path-cleanup.tf
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
- 
+
 locals {
   path_cleanup_name      = "path-cleanup"
   path_cleanup_full_name = "${local.k8s_app_alias}-path-cleanup"
@@ -39,9 +39,9 @@ resource "kubernetes_deployment" "beekeeper_path_cleanup" {
         labels = local.path_cleanup_label_name_instance
         annotations = {
           "iam.amazonaws.com/role" = aws_iam_role.beekeeper_k8s_role_path_cleanup_iam[count.index].arn
-          "prometheus.io/scrape": var.prometheus_enabled
-          "prometheus.io/port": var.k8s_path_cleanup_port
-          "prometheus.io/path": "/actuator/prometheus"
+          "prometheus.io/scrape" : var.prometheus_enabled
+          "prometheus.io/port" : var.k8s_path_cleanup_port
+          "prometheus.io/path" : "/actuator/prometheus"
         }
       }
 
@@ -65,11 +65,11 @@ resource "kubernetes_deployment" "beekeeper_path_cleanup" {
           }
 
           resources {
-            limits = {
+            limits {
               memory = var.k8s_path_cleanup_memory
               cpu    = var.k8s_path_cleanup_cpu
             }
-            requests = {
+            requests {
               memory = var.k8s_path_cleanup_memory
               cpu    = var.k8s_path_cleanup_cpu
             }
@@ -86,11 +86,11 @@ resource "kubernetes_deployment" "beekeeper_path_cleanup" {
           }
 
           env {
-            name  = local.db_password_key
+            name = local.db_password_key
             value_from {
               secret_key_ref {
-                name  = var.k8s_db_password_secret
-                key   = local.db_password_key
+                name = var.k8s_db_password_secret
+                key  = local.db_password_key
               }
             }
           }

--- a/k8s-scheduler-apiary.tf
+++ b/k8s-scheduler-apiary.tf
@@ -39,9 +39,9 @@ resource "kubernetes_deployment" "beekeeper_scheduler_apiary" {
         labels = local.scheduler_apiary_label_name_instance
         annotations = {
           "iam.amazonaws.com/role" = aws_iam_role.beekeeper_k8s_role_scheduler_apiary_iam[count.index].arn
-          "prometheus.io/scrape": var.prometheus_enabled
-          "prometheus.io/port": var.k8s_scheduler_apiary_port
-          "prometheus.io/path": "/actuator/prometheus"
+          "prometheus.io/scrape" : var.prometheus_enabled
+          "prometheus.io/port" : var.k8s_scheduler_apiary_port
+          "prometheus.io/path" : "/actuator/prometheus"
         }
       }
 
@@ -64,11 +64,11 @@ resource "kubernetes_deployment" "beekeeper_scheduler_apiary" {
           }
 
           resources {
-            limits = {
+            limits {
               memory = var.k8s_scheduler_apiary_memory
               cpu    = var.k8s_scheduler_apiary_cpu
             }
-            requests = {
+            requests {
               memory = var.k8s_scheduler_apiary_memory
               cpu    = var.k8s_scheduler_apiary_cpu
             }
@@ -85,11 +85,11 @@ resource "kubernetes_deployment" "beekeeper_scheduler_apiary" {
           }
 
           env {
-            name  = local.db_password_key
+            name = local.db_password_key
             value_from {
               secret_key_ref {
-                name  = var.k8s_db_password_secret
-                key   = local.db_password_key
+                name = var.k8s_db_password_secret
+                key  = local.db_password_key
               }
             }
           }

--- a/rds.tf
+++ b/rds.tf
@@ -56,8 +56,9 @@ resource "aws_db_instance" "beekeeper" {
   engine                 = "mysql"
   engine_version         = var.rds_engine_version
   instance_class         = var.rds_instance_class
-  // only alphanumeric char allowed in DB name, remove -
-  name                      = replace(local.instance_alias, "-", "")
+  // Don't use instance alias as part of default DB name since all the Flyway scripts expect "beekeeper" as the db name.
+  // No reason to parameterize the db name anyway, since we have a different RDS instance per Beekeeper instance.
+  name                      = "beekeeper"
   username                  = var.db_username
   password                  = chomp(data.aws_secretsmanager_secret_version.beekeeper_db.secret_string)
   parameter_group_name      = var.rds_parameter_group_name

--- a/rds.tf
+++ b/rds.tf
@@ -47,15 +47,15 @@ resource "random_id" "snapshot_id" {
 }
 
 resource "aws_db_instance" "beekeeper" {
-  identifier                = local.instance_alias
-  db_subnet_group_name      = aws_db_subnet_group.beekeeper_db_subnet_group.name
-  vpc_security_group_ids    = [aws_security_group.beekeeper_db_sg.id]
-  allocated_storage         = var.rds_allocated_storage
-  max_allocated_storage     = var.rds_max_allocated_storage
-  storage_type              = var.rds_storage_type
-  engine                    = "mysql"
-  engine_version            = var.rds_engine_version
-  instance_class            = var.rds_instance_class
+  identifier             = local.instance_alias
+  db_subnet_group_name   = aws_db_subnet_group.beekeeper_db_subnet_group.name
+  vpc_security_group_ids = [aws_security_group.beekeeper_db_sg.id]
+  allocated_storage      = var.rds_allocated_storage
+  max_allocated_storage  = var.rds_max_allocated_storage
+  storage_type           = var.rds_storage_type
+  engine                 = "mysql"
+  engine_version         = var.rds_engine_version
+  instance_class         = var.rds_instance_class
   // only alphanumeric char allowed in DB name, remove -
   name                      = replace(local.instance_alias, "-", "")
   username                  = var.db_username

--- a/version.tf
+++ b/version.tf
@@ -13,3 +13,4 @@ terraform {
     }
   }
 }
+

--- a/version.tf
+++ b/version.tf
@@ -5,7 +5,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = "> 0.12.0"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/version.tf
+++ b/version.tf
@@ -3,7 +3,13 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  */
- 
+
 terraform {
   required_version = ">= 0.12.0"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 1.0"
+    }
+  }
 }

--- a/version.tf
+++ b/version.tf
@@ -7,10 +7,7 @@
 terraform {
   required_version = "> 0.12.0"
   required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 1.0"
-    }
+    kubernetes = "~> 1.0"
   }
 }
 


### PR DESCRIPTION
## [2.1.4] - 2021-04-06
### Changed
- Pin K8S provider version to `1.x` for compatibility with other Apiary components deployed in the same Terraform state file.
- Don't use instance alias as part of default DB name since all the Flyway scripts expect "beekeeper" as the db name.

`terraform fmt` looks like it did some whitespace changes, so I suggest reviewing this PR with `Hide whitespace changes` turned on in the PR settings.