### PR TITLE
Fix Changelog for 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2021-04-06
+### Changed
+- Pin K8S provider version to `1.x` for compatibility with other Apiary components deployed in the same Terraform state file.
+- Don't use instance alias as part of default DB name since all the Flyway scripts expect "beekeeper" as the db name.
+
 ## [3.1.0] - 2021-02-22
 ### Changed
 - Removed variable `DB_PASSWORD_STRATEGY`.
@@ -21,11 +26,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Kubernetes deployment options for new Metadata Cleanup module. 
 ### Changed
 - Renamed `Cleanup` to `Path Cleanup`, and `Path Scheduler` to `Scheduler Apiary` to match name changes in Beekeeper.
-
-## [2.1.4] - 2021-04-06
-### Changed
-- Pin K8S provider version to `1.x` for compatibility with other Apiary components deployed in the same Terraform state file.
-- Don't use instance alias as part of default DB name since all the Flyway scripts expect "beekeeper" as the db name.
 
 ## [2.1.3] - 2020-08-07
 ### Changed


### PR DESCRIPTION
Well, that was an epic fail on my part for updating the Changelog in the last PR.  Not sure how that happened.

New release should be `3.1.1`