### PR TITLE
Add iops property to support storage type gp3 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2023-03-13
+### Added
+- Added variable `rds_iops` to support `rds_storage_type` : `gp3`(iops has to be specified when storage type is `gp3`).
+
 ## [3.3.0] - 2023-03-10
 ### Changed
 - Changed the `rds_storage_type` from `gp2` to `gp3`.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ A database password is defined in `aws-secrets-manager`. The terraform module wi
 | rds\_instance\_class | RDS instance class. | `string` | `"db.t2.micro"` | no |
 | rds\_max\_allocated\_storage | RDS max allocated storage (autoscaling) in GBs. | `string` | `100` | no |
 | rds\_parameter\_group\_name | RDS parameter group. | `string` | `"default.mysql8.0"` | no |
-| rds\_storage\_type | RDS storage type. | `string` | `"gp2"` | no |
+| rds\_storage\_type | RDS storage type. | `string` | `"gp3"` | no |
+| rds\_iops | RDS IOPS. | `number` | `3000` | no |
 | rds\_subnets | Subnets in which to provision Beekeeper RDS DB. | `list(string)` | n/a | yes |
 | receive\_wait\_time\_seconds | SQS receive wait time (s). | `number` | `20` | no |
 | scheduler\_apiary\_delay\_ms | Delay between each cleanup job that is scheduled in milliseconds. | `number` | `300000` | no |

--- a/rds.tf
+++ b/rds.tf
@@ -53,6 +53,7 @@ resource "aws_db_instance" "beekeeper" {
   allocated_storage      = var.rds_allocated_storage
   max_allocated_storage  = var.rds_max_allocated_storage
   storage_type           = var.rds_storage_type
+  iops                   = var.rds_iops
   engine                 = "mysql"
   engine_version         = var.rds_engine_version
   instance_class         = var.rds_instance_class

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,12 @@ variable "rds_storage_type" {
   type        = string
 }
 
+variable "rds_iops" {
+  description = "IO per seconds: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-storage-gp3-migration-selection.html"
+  default     = 3000
+  type        = number
+}
+
 variable "rds_instance_class" {
   description = "RDS instance class."
   default     = "db.t2.micro"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- 

### :link: Related Issues
- 
Error: Error modifying DB Instance beekeeper: InvalidParameterCombination: The storage type gp3 requires iops to be specified.
