### PR TITLE
Datadog annotations for sending metrics to Datadog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2024-08-30
+### Added
+- Added datadog annotations to send metrics from `scheduler-apiary`, `metadata-cleanup`, `path-cleanup` to DD.
+
 ## [5.0.5] - 2024-08-21
 ### Fixed
 - Add `copy_tags_to_snapshot` to aws_rds_cluster.

--- a/k8s-metadata-cleanup.tf
+++ b/k8s-metadata-cleanup.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_metadata_cleanup" {
         annotations = {
           "ad.datadoghq.com/${local.metadata_cleanup_full_name}.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/${local.metadata_cleanup_full_name}.init_configs": "[{}]"
-          "ad.datadoghq.com/${local.metadata_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [ \"${join("\",\"", var.beekeeper_metrics)}\" ]}]"
+          "ad.datadoghq.com/${local.metadata_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [ \"${join("\",\"", var.beekeeper_metadata_cleanup_metrics)}\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_metadata_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-metadata-cleanup.tf
+++ b/k8s-metadata-cleanup.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_metadata_cleanup" {
         annotations = {
           "ad.datadoghq.com/${local.metadata_cleanup_full_name}.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/${local.metadata_cleanup_full_name}.init_configs": "[{}]"
-          "ad.datadoghq.com/${local.metadata_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [\"s3_bytes_deleted_bytes_total*\", \"hive_table_metadata_deleted_total*\",\"hive_partition_metadata_deleted_total*\",\"s3_paths_deleted_seconds_sum*\", \"s3_paths_deleted_seconds_count*\", \"metadata_cleanup_job_seconds_sum*\", \"hive_table_deleted_seconds_count*\", \"disk_*\", \"jvm*\", \"hikaricp*\"] }]"
+          "ad.datadoghq.com/${local.metadata_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [ \"${join("\",\"", var.beekeeper_metrics)}\" ]}]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_metadata_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-metadata-cleanup.tf
+++ b/k8s-metadata-cleanup.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_metadata_cleanup" {
         annotations = {
           "ad.datadoghq.com/beekeeper-metadata-cleanup.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/beekeeper-metadata-cleanup.init_configs": "[{}]"
-          "ad.datadoghq.com/beekeeper-metadata-cleanup.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": \"beekeeper\", \"metrics\": [\"s3_bytes_deleted_bytes_total*\", \"hive_table_metadata_deleted_total*\",\"hive_partition_metadata_deleted_total*\",\"s3_paths_deleted_seconds_sum*\", \"s3_paths_deleted_seconds_count*\", \"metadata_cleanup_job_seconds_sum*\", \"hive_table_deleted_seconds_count*\", \"disk_*\", \"jvm*\", \"hikaricp*\"] }]"
+          "ad.datadoghq.com/beekeeper-metadata-cleanup.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"s3_bytes_deleted_bytes_total*\", \"hive_table_metadata_deleted_total*\",\"hive_partition_metadata_deleted_total*\",\"s3_paths_deleted_seconds_sum*\", \"s3_paths_deleted_seconds_count*\", \"metadata_cleanup_job_seconds_sum*\", \"hive_table_deleted_seconds_count*\", \"disk_*\", \"jvm*\", \"hikaricp*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_metadata_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-metadata-cleanup.tf
+++ b/k8s-metadata-cleanup.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_metadata_cleanup" {
         annotations = {
           "ad.datadoghq.com/${local.metadata_cleanup_full_name}.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/${local.metadata_cleanup_full_name}.init_configs": "[{}]"
-          "ad.datadoghq.com/${local.metadata_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"s3_bytes_deleted_bytes_total*\", \"hive_table_metadata_deleted_total*\",\"hive_partition_metadata_deleted_total*\",\"s3_paths_deleted_seconds_sum*\", \"s3_paths_deleted_seconds_count*\", \"metadata_cleanup_job_seconds_sum*\", \"hive_table_deleted_seconds_count*\", \"disk_*\", \"jvm*\", \"hikaricp*\"] }]"
+          "ad.datadoghq.com/${local.metadata_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [\"s3_bytes_deleted_bytes_total*\", \"hive_table_metadata_deleted_total*\",\"hive_partition_metadata_deleted_total*\",\"s3_paths_deleted_seconds_sum*\", \"s3_paths_deleted_seconds_count*\", \"metadata_cleanup_job_seconds_sum*\", \"hive_table_deleted_seconds_count*\", \"disk_*\", \"jvm*\", \"hikaricp*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_metadata_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-metadata-cleanup.tf
+++ b/k8s-metadata-cleanup.tf
@@ -38,6 +38,9 @@ resource "kubernetes_deployment_v1" "beekeeper_metadata_cleanup" {
       metadata {
         labels = local.metadata_cleanup_label_name_instance
         annotations = {
+          "ad.datadoghq.com/beekeeper-metadata-cleanup.check_names": "[\"openmetrics\"]"
+          "ad.datadoghq.com/beekeeper-metadata-cleanup.init_configs": "[{}]"
+          "ad.datadoghq.com/beekeeper-metadata-cleanup.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": \"beekeeper\", \"metrics\": [\"s3_bytes_deleted_bytes_total*\", \"hive_table_metadata_deleted_total*\",\"hive_partition_metadata_deleted_total*\",\"s3_paths_deleted_seconds_sum*\", \"s3_paths_deleted_seconds_count*\", \"metadata_cleanup_job_seconds_sum*\", \"hive_table_deleted_seconds_count*\", \"disk_*\", \"jvm*\", \"hikaricp*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_metadata_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-metadata-cleanup.tf
+++ b/k8s-metadata-cleanup.tf
@@ -38,9 +38,9 @@ resource "kubernetes_deployment_v1" "beekeeper_metadata_cleanup" {
       metadata {
         labels = local.metadata_cleanup_label_name_instance
         annotations = {
-          "ad.datadoghq.com/beekeeper-metadata-cleanup.check_names": "[\"openmetrics\"]"
-          "ad.datadoghq.com/beekeeper-metadata-cleanup.init_configs": "[{}]"
-          "ad.datadoghq.com/beekeeper-metadata-cleanup.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"s3_bytes_deleted_bytes_total*\", \"hive_table_metadata_deleted_total*\",\"hive_partition_metadata_deleted_total*\",\"s3_paths_deleted_seconds_sum*\", \"s3_paths_deleted_seconds_count*\", \"metadata_cleanup_job_seconds_sum*\", \"hive_table_deleted_seconds_count*\", \"disk_*\", \"jvm*\", \"hikaricp*\"] }]"
+          "ad.datadoghq.com/${local.metadata_cleanup_full_name}.check_names": "[\"openmetrics\"]"
+          "ad.datadoghq.com/${local.metadata_cleanup_full_name}.init_configs": "[{}]"
+          "ad.datadoghq.com/${local.metadata_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:9008/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"s3_bytes_deleted_bytes_total*\", \"hive_table_metadata_deleted_total*\",\"hive_partition_metadata_deleted_total*\",\"s3_paths_deleted_seconds_sum*\", \"s3_paths_deleted_seconds_count*\", \"metadata_cleanup_job_seconds_sum*\", \"hive_table_deleted_seconds_count*\", \"disk_*\", \"jvm*\", \"hikaricp*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_metadata_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-path-cleanup.tf
+++ b/k8s-path-cleanup.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_path_cleanup" {
         annotations = {
           "ad.datadoghq.com/${local.path_cleanup_full_name}.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/${local.path_cleanup_full_name}.init_configs": "[{}]"
-          "ad.datadoghq.com/${local.path_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8008/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
+          "ad.datadoghq.com/${local.path_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8008/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_path_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-path-cleanup.tf
+++ b/k8s-path-cleanup.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_path_cleanup" {
         annotations = {
           "ad.datadoghq.com/${local.path_cleanup_full_name}.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/${local.path_cleanup_full_name}.init_configs": "[{}]"
-          "ad.datadoghq.com/${local.path_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8008/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
+          "ad.datadoghq.com/${local.path_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8008/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [ \"${join("\",\"", var.beekeeper_path_cleanup_metrics)}\"]  }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_path_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-path-cleanup.tf
+++ b/k8s-path-cleanup.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_path_cleanup" {
         annotations = {
           "ad.datadoghq.com/beekeeper-path-cleanup.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/beekeeper-path-cleanup.init_configs": "[{}]"
-          "ad.datadoghq.com/beekeeper-path-cleanup.instances": "[{ \"prometheus_url\": \"http://%%host%%:8008/actuator/prometheus\", \"namespace\": \"beekeeper\", \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
+          "ad.datadoghq.com/beekeeper-path-cleanup.instances": "[{ \"prometheus_url\": \"http://%%host%%:8008/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_path_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-path-cleanup.tf
+++ b/k8s-path-cleanup.tf
@@ -38,9 +38,9 @@ resource "kubernetes_deployment_v1" "beekeeper_path_cleanup" {
       metadata {
         labels = local.path_cleanup_label_name_instance
         annotations = {
-          "ad.datadoghq.com/beekeeper-path-cleanup.check_names": "[\"openmetrics\"]"
-          "ad.datadoghq.com/beekeeper-path-cleanup.init_configs": "[{}]"
-          "ad.datadoghq.com/beekeeper-path-cleanup.instances": "[{ \"prometheus_url\": \"http://%%host%%:8008/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
+          "ad.datadoghq.com/${local.path_cleanup_full_name}.check_names": "[\"openmetrics\"]"
+          "ad.datadoghq.com/${local.path_cleanup_full_name}.init_configs": "[{}]"
+          "ad.datadoghq.com/${local.path_cleanup_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8008/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_path_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-path-cleanup.tf
+++ b/k8s-path-cleanup.tf
@@ -38,6 +38,9 @@ resource "kubernetes_deployment_v1" "beekeeper_path_cleanup" {
       metadata {
         labels = local.path_cleanup_label_name_instance
         annotations = {
+          "ad.datadoghq.com/beekeeper-path-cleanup.check_names": "[\"openmetrics\"]"
+          "ad.datadoghq.com/beekeeper-path-cleanup.init_configs": "[{}]"
+          "ad.datadoghq.com/beekeeper-path-cleanup.instances": "[{ \"prometheus_url\": \"http://%%host%%:8008/actuator/prometheus\", \"namespace\": \"beekeeper\", \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_path_cleanup_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-scheduler-apiary.tf
+++ b/k8s-scheduler-apiary.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_scheduler_apiary" {
         annotations = {
           "ad.datadoghq.com/${local.scheduler_apiary_full_name}.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/${local.scheduler_apiary_full_name}.init_configs": "[{}]"
-          "ad.datadoghq.com/${local.scheduler_apiary_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8080/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
+          "ad.datadoghq.com/${local.scheduler_apiary_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8080/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [ \"${join("\",\"", var.beekeeper_scheduler_apiary_metrics)}\"]  }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_scheduler_apiary_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-scheduler-apiary.tf
+++ b/k8s-scheduler-apiary.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_scheduler_apiary" {
         annotations = {
           "ad.datadoghq.com/beekeeper-scheduler-apiary.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/beekeeper-scheduler-apiary.init_configs": "[{}]"
-          "ad.datadoghq.com/beekeeper-scheduler-apiary.instances": "[{ \"prometheus_url\": \"http://%%host%%:8080/actuator/prometheus\", \"namespace\": \"beekeeper\", \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
+          "ad.datadoghq.com/beekeeper-scheduler-apiary.instances": "[{ \"prometheus_url\": \"http://%%host%%:8080/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_scheduler_apiary_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-scheduler-apiary.tf
+++ b/k8s-scheduler-apiary.tf
@@ -38,6 +38,9 @@ resource "kubernetes_deployment_v1" "beekeeper_scheduler_apiary" {
       metadata {
         labels = local.scheduler_apiary_label_name_instance
         annotations = {
+          "ad.datadoghq.com/beekeeper-scheduler-apiary.check_names": "[\"openmetrics\"]"
+          "ad.datadoghq.com/beekeeper-scheduler-apiary.init_configs": "[{}]"
+          "ad.datadoghq.com/beekeeper-scheduler-apiary.instances": "[{ \"prometheus_url\": \"http://%%host%%:8080/actuator/prometheus\", \"namespace\": \"beekeeper\", \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_scheduler_apiary_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-scheduler-apiary.tf
+++ b/k8s-scheduler-apiary.tf
@@ -38,9 +38,9 @@ resource "kubernetes_deployment_v1" "beekeeper_scheduler_apiary" {
       metadata {
         labels = local.scheduler_apiary_label_name_instance
         annotations = {
-          "ad.datadoghq.com/beekeeper-scheduler-apiary.check_names": "[\"openmetrics\"]"
-          "ad.datadoghq.com/beekeeper-scheduler-apiary.init_configs": "[{}]"
-          "ad.datadoghq.com/beekeeper-scheduler-apiary.instances": "[{ \"prometheus_url\": \"http://%%host%%:8080/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
+          "ad.datadoghq.com/${local.scheduler_apiary_full_name}.check_names": "[\"openmetrics\"]"
+          "ad.datadoghq.com/${local.scheduler_apiary_full_name}.init_configs": "[{}]"
+          "ad.datadoghq.com/${local.scheduler_apiary_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8080/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_scheduler_apiary_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/k8s-scheduler-apiary.tf
+++ b/k8s-scheduler-apiary.tf
@@ -40,7 +40,7 @@ resource "kubernetes_deployment_v1" "beekeeper_scheduler_apiary" {
         annotations = {
           "ad.datadoghq.com/${local.scheduler_apiary_full_name}.check_names": "[\"openmetrics\"]"
           "ad.datadoghq.com/${local.scheduler_apiary_full_name}.init_configs": "[{}]"
-          "ad.datadoghq.com/${local.scheduler_apiary_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8080/actuator/prometheus\", \"namespace\": ${local.instance_alias}, \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
+          "ad.datadoghq.com/${local.scheduler_apiary_full_name}.instances": "[{ \"prometheus_url\": \"http://%%host%%:8080/actuator/prometheus\", \"namespace\": \"${local.instance_alias}\", \"metrics\": [\"path_cleanup_job_seconds_sum*\"] }]"
           "prometheus.io/scrape" : var.prometheus_enabled
           "prometheus.io/port" : var.k8s_scheduler_apiary_port
           "prometheus.io/path" : "/actuator/prometheus"

--- a/variables.tf
+++ b/variables.tf
@@ -570,3 +570,20 @@ variable "db_copy_tags_to_snapshot" {
     type        = bool
     default     = true
 }
+
+variable "beekeeper_metrics" {
+  description = "WaggleDance metrics to be sent to Datadog."
+  type        = list(string)
+  default = [
+    "s3_bytes_deleted_bytes_total*",
+    "hive_table_metadata_deleted_total*",
+    "hive_partition_metadata_deleted_total*",
+    "s3_paths_deleted_seconds_sum*",
+    "s3_paths_deleted_seconds_count*",
+    "metadata_cleanup_job_seconds_sum*",
+    "hive_table_deleted_seconds_count*",
+    "disk_*",
+    "jvm*",
+    "hikaricp*"
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -571,8 +571,8 @@ variable "db_copy_tags_to_snapshot" {
     default     = true
 }
 
-variable "beekeeper_metrics" {
-  description = "WaggleDance metrics to be sent to Datadog."
+variable "beekeeper_metadata_cleanup_metrics" {
+  description = "Beekeeper metrics to be sent to Datadog."
   type        = list(string)
   default = [
     "s3_bytes_deleted_bytes_total*",
@@ -585,5 +585,21 @@ variable "beekeeper_metrics" {
     "disk_*",
     "jvm*",
     "hikaricp*"
+  ]
+}
+
+variable "beekeeper_scheduler_apiary_metrics" {
+  description = "Beekeeper metrics to be sent to Datadog."
+  type        = list(string)
+  default = [
+    "path_cleanup_job_seconds_sum*"
+  ]
+}
+
+variable "beekeeper_path_cleanup_metrics" {
+  description = "Beekeeper metrics to be sent to Datadog."
+  type        = list(string)
+  default = [
+    "path_cleanup_job_seconds_sum*"
   ]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description : Added datadog annotations to send metrics from `scheduler-apiary`, `metadata-cleanup`, `path-cleanup` to DD.
- 

### :link: Related Issues: Currently we don't have these metrics flowing in Datadog.
- 
